### PR TITLE
fix console warnings about missing mod.conf

### DIFF
--- a/game.conf
+++ b/game.conf
@@ -1,3 +1,3 @@
-name = 100 Minerals to Success
+title = 100 Minerals to Success
 description = Mine Minerals, Craft Pickaxes and dig deeper!
 allowed_mapgens = singlenode

--- a/mods/mts_bedrock/mod.conf
+++ b/mods/mts_bedrock/mod.conf
@@ -1,0 +1,4 @@
+name = mts_bedrock
+description = Adds bedrock nodes.
+depends =
+optional_depends =

--- a/mods/mts_commands/mod.conf
+++ b/mods/mts_commands/mod.conf
@@ -1,0 +1,4 @@
+name = mts_commands
+description = Adds MTS commands.
+depends =
+optional_depends =

--- a/mods/mts_default/mod.conf
+++ b/mods/mts_default/mod.conf
@@ -1,0 +1,4 @@
+name = mts_default
+description = The base of the MTS game.
+depends =
+optional_depends =

--- a/mods/mts_lights/mod.conf
+++ b/mods/mts_lights/mod.conf
@@ -1,0 +1,4 @@
+name = mts_lights
+description = Adds light emitting nodes.
+depends =
+optional_depends =

--- a/mods/mts_liquids/mod.conf
+++ b/mods/mts_liquids/mod.conf
@@ -1,0 +1,4 @@
+name = mts_liquids
+description = Adds underground liquids.
+depends =
+optional_depends =

--- a/mods/mts_mapgen/depends.txt
+++ b/mods/mts_mapgen/depends.txt
@@ -1,6 +1,0 @@
-mts_default
-mts_lights
-mts_bedrock
-mts_liquids
-mts_plants
-mts_teleporters

--- a/mods/mts_mapgen/mod.conf
+++ b/mods/mts_mapgen/mod.conf
@@ -1,0 +1,4 @@
+name = mts_mapgen
+description = Handles MTS world generation.
+depends = mts_default, mts_lights, mts_bedrock, mts_liquids, mts_plants, mts_teleporters
+optional_depends =

--- a/mods/mts_plants/mod.conf
+++ b/mods/mts_plants/mod.conf
@@ -1,0 +1,4 @@
+name = mts_plants
+description = Adds plants for surface decoration.
+depends =
+optional_depends =


### PR DESCRIPTION
Prevents this:
![image](https://user-images.githubusercontent.com/48406239/185914419-80cd10ea-fd4e-4a49-86af-1da158335310.png)
from appearing in the console every time the game is started.